### PR TITLE
Bump to v2.0.0

### DIFF
--- a/Formula/moodle-sdk.rb
+++ b/Formula/moodle-sdk.rb
@@ -5,9 +5,9 @@ require 'formula'
 
 class MoodleSdk < Formula
   homepage 'https://github.com/FMCorz/mdk/'
-  url 'https://github.com/FMCorz/mdk/archive/v1.7.5.zip'
-  sha256 'bc3de47237df1982641ac7eaf88f4854a6c2cbd27d37cfe1a4be99ad4c8ef61a'
-  version '1.7.5'
+  url 'https://github.com/FMCorz/mdk/archive/v2.0.0.zip'
+  sha256 'edffc4ed85269a92f2fecd57367e3b558aee5d61a7711ac7fbd2582203886b9d'
+  version '2.0.0'
 
   def install
       dir = (libexec+'moodle-sdk')


### PR DESCRIPTION
Hi Dan, MDK 2.0.0 which supports Python 3 has been released.

Thanks!